### PR TITLE
POC: Enable injection of checks that run before exit

### DIFF
--- a/lib/rubocop/git/cli.rb
+++ b/lib/rubocop/git/cli.rb
@@ -31,8 +31,13 @@ module RuboCop
           end
 
           opt.on('-r', '--require FILE',
-                 'Require Ruby file') do |file|
+                 'Require Ruby file before running checks') do |file|
             require file
+          end
+
+          opt.on('-R', '--run-after FILE',
+                'Require Ruby file and call `#run` on its class, after running usual checks') do |file|
+            @options.rubocop[:require_after] = file
           end
 
           opt.on('-d', '--debug', 'Display debug info') do

--- a/lib/rubocop/git/runner.rb
+++ b/lib/rubocop/git/runner.rb
@@ -12,6 +12,8 @@ module RuboCop
 
         display_violations($stdout)
 
+        require_after(options.rubocop[:require_after])
+
         exit(1) if violations.any?
       end
 
@@ -56,6 +58,20 @@ module RuboCop
         end
 
         formatter.finished(@files.map(&:filename).freeze)
+      end
+
+      def require_after(file = nil)
+        if file
+          require file
+          klass = classify(file)
+          klass.run(@files)
+        end
+      end
+
+      def classify(string)
+        string.gsub!(/(^\.\/)|(\.rb)/,'')
+        klass = string.to_s.split('_').collect(&:capitalize).join
+        Object.const_get(klass)
       end
     end
   end

--- a/lib/rubocop/git/version.rb
+++ b/lib/rubocop/git/version.rb
@@ -1,5 +1,5 @@
 module RuboCop
   module Git
-    VERSION = '0.1.3'
+    VERSION = '0.1.3.345'
   end
 end


### PR DESCRIPTION
Quick e.g. code that you can put in `/version_check.rb` and then call `rubocop-git -R ./version_check.rb -D master`

```ruby
class VersionCheck
  def self.run(changeset)
    if !changeset.empty?
      files = changeset.map { |change| change.filename }
      raise 'You forgot to update the version!' unless files.include?('lib/rubocop/git/version.rb')
    end
  end
end
```